### PR TITLE
Modified basename variable to stop too few X template errors on newer…

### DIFF
--- a/analyse-access.sh
+++ b/analyse-access.sh
@@ -12,7 +12,7 @@ set -e
 # you can save the output by a simple piping
 #    ./analyse-access.sh access.log.2013-* | tee yr2013.md
 
-BN=`basename $0`
+BN="$(basename $0).XXXX"
 
 if [ $# -lt 1 ] 
 then


### PR DESCRIPTION
Resolves 'too few X's in template' error observed in RHEL 6.9 production. Previous version, which worked fine on Mac, works with this change as well. 